### PR TITLE
fileSelect Component accepts props

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,19 +10,21 @@ module.exports = React => {
     let onTextResult;
     let onPath;
 
-    function Comp () {
-        return $('input', {
-            type: 'file',
-            style: {
-                display: 'none'
-            },
-            onChange: event => {
-                onLoad(event, onTextResult, onPath);
-            },
-            ref: function (input) {
-                ref = input;
-            }
-        });
+    function Comp (props) {
+        return $('input',
+            Object.assign({
+                type: 'file',
+                style: {
+                    display: 'none'
+                },
+                onChange: event => {
+                    onLoad(event, onTextResult, onPath);
+                },
+                ref: function (input) {
+                    ref = input;
+                }
+            }, props)
+        )
     }
 
     return {

--- a/src/app.js
+++ b/src/app.js
@@ -29,7 +29,7 @@ class App extends React.Component {
                 $('span', {}),
                 $('span', {}),
                 $('span', {}),
-                $(fs1.Comp, {})
+                $(fs1.Comp, { accept: '.txt'})
             )
         );
     }


### PR DESCRIPTION
There is only one problem.
Suppose nwjs has custom attributes for `<input type='file' nwdirectory>` and react doesn't understand it right now.
There is a workaround solution to implement it through
this.ref.myInput.getDOMNode().setAttribute('nwdirectory')
let me know if it is needed to be implemented