### PR TITLE
Fixing bug when you cannot load same file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,12 +19,13 @@ module.exports = React => {
                 },
                 onChange: event => {
                     onLoad(event, onTextResult, onPath);
+                    ref.value = '';
                 },
                 ref: function (input) {
                     ref = input;
                 }
             }, props)
-        )
+        );
     }
 
     return {


### PR DESCRIPTION
The problem was when you couldn't load same file twice, because onChange method is not triggered with the same path.

Quick solution is to put empty string to the value of input